### PR TITLE
Module 11 - Spring Security Core - ACL with Spring Security

### DIFF
--- a/m11-lesson3/pom.xml
+++ b/m11-lesson3/pom.xml
@@ -83,16 +83,18 @@
             <artifactId>spring-boot-starter-data-jpa</artifactId>
         </dependency>
 
+
         <dependency>
             <groupId>org.hsqldb</groupId>
             <artifactId>hsqldb</artifactId>
-            <scope>runtime</scope>
+<!--            <scope>test</scope>-->
         </dependency>
 
-<!--         <dependency> -->
-<!--             <groupId>mysql</groupId> -->
-<!--             <artifactId>mysql-connector-java</artifactId> -->
-<!--         </dependency> -->
+        <dependency>
+             <groupId>mysql</groupId>
+             <artifactId>mysql-connector-java</artifactId>
+             <version>${mysql.version}</version>
+         </dependency>
 
         <!-- mail -->
 
@@ -126,6 +128,17 @@
             <artifactId>log4j-over-slf4j</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-acl</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>net.sf.ehcache</groupId>
+            <artifactId>ehcache-core</artifactId>
+            <version>2.6.11</version>
+        </dependency>
+
         <!-- test scoped -->
 
         <dependency>
@@ -142,6 +155,18 @@
                 <exclusion>
                     <groupId>org.hamcrest</groupId>
                     <artifactId>hamcrest-core</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <artifactId>commons-logging</artifactId>
+                    <groupId>commons-logging</groupId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/m11-lesson3/src/main/java/com/baeldung/lss/model/IEntity.java
+++ b/m11-lesson3/src/main/java/com/baeldung/lss/model/IEntity.java
@@ -1,0 +1,6 @@
+package com.baeldung.lss.model;
+
+public interface IEntity {
+
+    public Long getId();
+}

--- a/m11-lesson3/src/main/java/com/baeldung/lss/model/Possession.java
+++ b/m11-lesson3/src/main/java/com/baeldung/lss/model/Possession.java
@@ -1,0 +1,115 @@
+package com.baeldung.lss.model;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+
+@Entity
+@Table(name = "possession")
+public class Possession implements IEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String name;
+
+    @ManyToOne
+    @JoinColumn(name = "owner_id", nullable = false)
+    private User owner;
+
+    public Possession() {
+    }
+
+    public Possession(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public User getOwner() {
+        return owner;
+    }
+
+    public void setOwner(User owner) {
+        this.owner = owner;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = (prime * result) + ((id == null) ? 0 : id.hashCode());
+        result = (prime * result) + ((name == null) ? 0 : name.hashCode());
+        result = (prime * result) + ((owner == null) ? 0 : owner.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        final Possession other = (Possession) obj;
+        if (id == null) {
+            if (other.id != null) {
+                return false;
+            }
+        } else if (!id.equals(other.id)) {
+            return false;
+        }
+        if (name == null) {
+            if (other.name != null) {
+                return false;
+            }
+        } else if (!name.equals(other.name)) {
+            return false;
+        }
+        if (owner == null) {
+            if (other.owner != null) {
+                return false;
+            }
+        } else if (!owner.equals(other.owner)) {
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public String toString() {
+        final StringBuilder builder = new StringBuilder();
+        builder.append("Possession [id=")
+            .append(id)
+            .append(", name=")
+            .append(name)
+            .append(", owner=")
+            .append(owner)
+            .append("]");
+        return builder.toString();
+    }
+
+}

--- a/m11-lesson3/src/main/java/com/baeldung/lss/model/User.java
+++ b/m11-lesson3/src/main/java/com/baeldung/lss/model/User.java
@@ -4,6 +4,7 @@ import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.Table;
 import javax.persistence.Transient;
 
 import com.baeldung.lss.validation.PasswordMatches;
@@ -13,6 +14,7 @@ import javax.validation.constraints.NotEmpty;
 
 @Entity
 @PasswordMatches
+@Table(name = "users")
 public class User {
 
     @Id

--- a/m11-lesson3/src/main/java/com/baeldung/lss/persistence/PossessionRepository.java
+++ b/m11-lesson3/src/main/java/com/baeldung/lss/persistence/PossessionRepository.java
@@ -1,0 +1,8 @@
+package com.baeldung.lss.persistence;
+
+import com.baeldung.lss.model.Possession;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PossessionRepository extends JpaRepository<Possession, Long> {
+
+}

--- a/m11-lesson3/src/main/java/com/baeldung/lss/security/LssAclPermissionService.java
+++ b/m11-lesson3/src/main/java/com/baeldung/lss/security/LssAclPermissionService.java
@@ -1,0 +1,83 @@
+package com.baeldung.lss.security;
+
+import com.baeldung.lss.model.IEntity;
+import javax.transaction.Transactional;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.acls.domain.GrantedAuthoritySid;
+import org.springframework.security.acls.domain.ObjectIdentityImpl;
+import org.springframework.security.acls.domain.PrincipalSid;
+import org.springframework.security.acls.model.MutableAcl;
+import org.springframework.security.acls.model.MutableAclService;
+import org.springframework.security.acls.model.NotFoundException;
+import org.springframework.security.acls.model.ObjectIdentity;
+import org.springframework.security.acls.model.Permission;
+import org.springframework.security.acls.model.Sid;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionStatus;
+import org.springframework.transaction.support.TransactionCallbackWithoutResult;
+import org.springframework.transaction.support.TransactionTemplate;
+
+@Service
+@Transactional
+public class LssAclPermissionService {
+
+  private final MutableAclService aclService;
+  private final PlatformTransactionManager transactionManager;
+
+  @Autowired
+  public LssAclPermissionService(MutableAclService aclService,
+                                PlatformTransactionManager transactionManager) {
+    this.aclService = aclService;
+    this.transactionManager = transactionManager;
+  }
+
+  public void addUserPermission(IEntity targetEntity, Permission permission, String username) {
+    Sid sid = new PrincipalSid(username);
+    addSidPermissionInTx(targetEntity, permission, sid);
+  }
+
+
+  public void addRolePermission(IEntity targetEntity, Permission permission, String username) {
+    Sid sid = new GrantedAuthoritySid(username);
+    addSidPermission(targetEntity, permission, sid);
+  }
+
+
+  private void addSidPermission(IEntity targetEntity, Permission permission, Sid sid) {
+    var objectIdentity = new ObjectIdentityImpl(targetEntity.getClass(), targetEntity.getId());
+    MutableAcl acl;
+
+    try {
+      acl = (MutableAcl) aclService.readAclById(objectIdentity);
+    } catch (NotFoundException e) {
+      acl =  aclService.createAcl(objectIdentity);
+    }
+
+    acl.insertAce(acl.getEntries().size(), permission, sid, true);
+    aclService.updateAcl(acl);
+  }
+
+
+  private void addSidPermissionInTx(IEntity targetObj, Permission permission, Sid sid) {
+    final TransactionTemplate tt = new TransactionTemplate(transactionManager);
+
+    tt.execute(new TransactionCallbackWithoutResult() {
+      @Override
+      protected void doInTransactionWithoutResult(TransactionStatus status) {
+        final ObjectIdentity oi = new ObjectIdentityImpl(targetObj.getClass(), targetObj.getId());
+
+        MutableAcl acl = null;
+        try {
+          acl = (MutableAcl) aclService.readAclById(oi);
+        } catch (final NotFoundException nfe) {
+          acl = aclService.createAcl(oi);
+        }
+
+        acl.insertAce(acl.getEntries()
+            .size(), permission, sid, true);
+        aclService.updateAcl(acl);
+      }
+    });
+  }
+}

--- a/m11-lesson3/src/main/java/com/baeldung/lss/spring/LssGlobalMethodSecurityConfig.java
+++ b/m11-lesson3/src/main/java/com/baeldung/lss/spring/LssGlobalMethodSecurityConfig.java
@@ -1,0 +1,117 @@
+package com.baeldung.lss.spring;
+
+import java.util.Objects;
+import javax.sql.DataSource;
+import net.sf.ehcache.CacheManager;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.cache.ehcache.EhCacheFactoryBean;
+import org.springframework.cache.ehcache.EhCacheManagerFactoryBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.jdbc.datasource.DriverManagerDataSource;
+import org.springframework.security.access.expression.method.DefaultMethodSecurityExpressionHandler;
+import org.springframework.security.access.expression.method.MethodSecurityExpressionHandler;
+import org.springframework.security.acls.AclPermissionEvaluator;
+import org.springframework.security.acls.domain.AclAuthorizationStrategy;
+import org.springframework.security.acls.domain.AclAuthorizationStrategyImpl;
+import org.springframework.security.acls.domain.ConsoleAuditLogger;
+import org.springframework.security.acls.domain.DefaultPermissionGrantingStrategy;
+import org.springframework.security.acls.domain.EhCacheBasedAclCache;
+import org.springframework.security.acls.jdbc.BasicLookupStrategy;
+import org.springframework.security.acls.jdbc.JdbcMutableAclService;
+import org.springframework.security.acls.jdbc.LookupStrategy;
+import org.springframework.security.acls.model.AclCache;
+import org.springframework.security.acls.model.PermissionGrantingStrategy;
+import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
+import org.springframework.security.config.annotation.method.configuration.GlobalMethodSecurityConfiguration;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+
+@Configuration
+@EnableGlobalMethodSecurity(prePostEnabled = true)
+public class LssGlobalMethodSecurityConfig extends GlobalMethodSecurityConfiguration {
+
+  @Value("${spring.datasource.driver-class-name}")
+  private String driverClassName;
+
+  @Value("${spring.datasource.url}")
+  private String dataSourceURL;
+
+  @Value("${spring.datasource.username}")
+  private String dataSourceUserName;
+
+  @Value("${spring.datasource.password}")
+  private String dataSourcePassword;
+
+  @Override
+  public MethodSecurityExpressionHandler createExpressionHandler() {
+    var expressionHandler = new DefaultMethodSecurityExpressionHandler();
+    expressionHandler.setPermissionEvaluator(aclPermissionEvaluator());
+    return expressionHandler;
+  }
+
+  @Bean
+  public AclPermissionEvaluator aclPermissionEvaluator() {
+    return  new AclPermissionEvaluator(aclService());
+  }
+
+  @Bean
+  public JdbcMutableAclService aclService() {
+    var aclService = new JdbcMutableAclService(dataSource(), lookupStrategy(), aclCache());
+    aclService.setClassIdentityQuery("SELECT @@IDENTITY");
+    aclService.setSidIdentityQuery("SELECT @@IDENTITY");
+    return aclService;
+  }
+
+  @Bean
+  public LookupStrategy lookupStrategy() {
+    return new BasicLookupStrategy(dataSource(),
+                                  aclCache(),
+                                  aclAuthorizationStrategy(),
+                                  permissionGrantingStrategy());
+  }
+
+  @Bean
+  public AclCache aclCache() {
+    EhCacheManagerFactoryBean cacheManager = new EhCacheManagerFactoryBean();
+    cacheManager.setAcceptExisting(true);
+    cacheManager.setCacheManagerName(CacheManager.getInstance().getName());
+    cacheManager.afterPropertiesSet();
+
+    EhCacheFactoryBean cacheFactoryBean = new EhCacheFactoryBean();
+    cacheFactoryBean.setName("aclCache");
+    cacheFactoryBean.setCacheManager(Objects.requireNonNull(cacheManager.getObject()));
+    cacheFactoryBean.setMaxBytesLocalHeap("16M");
+    cacheFactoryBean.setMaxEntriesLocalHeap(0L);
+    cacheFactoryBean.afterPropertiesSet();
+
+    return new EhCacheBasedAclCache(cacheFactoryBean.getObject(),
+                                    permissionGrantingStrategy(),
+                                    aclAuthorizationStrategy());
+  }
+
+  @Bean
+  public AclAuthorizationStrategy aclAuthorizationStrategy() {
+    return new AclAuthorizationStrategyImpl(new SimpleGrantedAuthority("ADMIN"));
+  }
+
+  @Bean
+  public PermissionGrantingStrategy permissionGrantingStrategy() {
+    return new DefaultPermissionGrantingStrategy(new ConsoleAuditLogger());
+  }
+
+  @Bean
+  @ConfigurationProperties(prefix = "spring.datasource")
+  public DataSource dataSource() {
+    DriverManagerDataSource dataSource = new DriverManagerDataSource();
+    dataSource.setDriverClassName(driverClassName);
+    dataSource.setPassword(dataSourcePassword);
+    dataSource.setUsername(dataSourceUserName);
+    dataSource.setUrl(dataSourceURL);
+    return dataSource;
+  }
+
+
+
+
+}

--- a/m11-lesson3/src/main/java/com/baeldung/lss/web/controller/PossessionController.java
+++ b/m11-lesson3/src/main/java/com/baeldung/lss/web/controller/PossessionController.java
@@ -1,0 +1,51 @@
+package com.baeldung.lss.web.controller;
+
+import com.baeldung.lss.model.Possession;
+import com.baeldung.lss.persistence.PossessionRepository;
+import com.baeldung.lss.persistence.UserRepository;
+import com.baeldung.lss.security.LssAclPermissionService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.access.prepost.PostAuthorize;
+import org.springframework.security.acls.domain.BasePermission;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+@Controller
+public class PossessionController {
+
+  private final UserRepository userRepository;
+  private final PossessionRepository possessionRepository;
+  private final LssAclPermissionService lssAclPermissionService;
+
+  @Autowired
+  public PossessionController(UserRepository userRepository,
+                              PossessionRepository possessionRepository,
+                              LssAclPermissionService lssAclPermissionService) {
+    this.userRepository = userRepository;
+    this.possessionRepository = possessionRepository;
+    this.lssAclPermissionService = lssAclPermissionService;
+  }
+
+  @RequestMapping(value = "/possessions/{id}", method = RequestMethod.GET)
+  @ResponseBody
+  @PostAuthorize("hasPermission(returnObject, 'READ') or hasPermission(returnObject, 'ADMINISTRATION')")
+  public Possession findOne(@PathVariable("id") final Long id) {
+    return possessionRepository.findById(id).orElse(null);
+  }
+
+  // this is just to test all the logic should be inside the separate service
+  @RequestMapping(value = "/possessions", method = RequestMethod.POST)
+  @ResponseBody
+  public String create(@RequestBody Possession possession, Authentication authentication) {
+    possession.setOwner(userRepository.findByEmail(authentication.getName()));
+    possession = possessionRepository.save(possession);
+    lssAclPermissionService.addUserPermission(possession, BasePermission.ADMINISTRATION, authentication.getName());
+    return "Possession created with id " + possession.getId();
+  }
+
+}

--- a/m11-lesson3/src/main/resources/application.properties
+++ b/m11-lesson3/src/main/resources/application.properties
@@ -5,16 +5,17 @@ server.tomcat.basedir=target/tomcat
 server.port=8081
 
 # Hibernate
-spring.jpa.hibernate.ddl-auto=update
+spring.sql.init.mode=always
 
 # Persistence
 spring.jpa.properties.javax.persistence.validation.mode=none
 spring.jpa.open-in-view=false
 
-#spring.datasource.url=jdbc:mysql://localhost/lss62?createDatabaseIfNotExist=true
-#spring.datasource.username=restUser
-#spring.datasource.password=restmy5ql
-#spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+spring.sql.init.platform=mysql
+spring.datasource.url=jdbc:mysql://localhost:3306/lss114?createDatabaseIfNotExist=true
+spring.datasource.username=root
+spring.datasource.password=root
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 
 
 # Mail

--- a/m11-lesson3/src/main/resources/data.sql
+++ b/m11-lesson3/src/main/resources/data.sql
@@ -1,0 +1,34 @@
+INSERT INTO users (id, email, password) VALUES
+-- User eugen@email.com/pass
+(1, 'eugen@email.com', '$2a$04$kqRvgmJBlWZQQ2c9NT9IH.ZhxFY07Y2xE73vmLHxBq2hNTvGvUc5m'),
+-- User eric@email.com/123
+(2, 'eric@email.com', '$2a$10$BuPWnSrcLPxwMcCwu7eyBu/x7817Mo3MzYbZGVFfgIewEUUXPmpy6'),
+-- User test@user.com/pass
+(3, 'test@user.com', '$2a$04$kqRvgmJBlWZQQ2c9NT9IH.ZhxFY07Y2xE73vmLHxBq2hNTvGvUc5m');
+
+INSERT INTO possession (id, name, owner_id) VALUES
+(1, 'Eugen Possession', 1),
+(2, 'Common Possesion', 1),
+(3, 'Eric Possession', 2),
+(4, 'Test Possession', 3);
+
+INSERT INTO acl_sid (id, principal, sid) VALUES
+(1, 1, 'eugen@email.com'),
+(2, 1, 'eric@email.com'),
+(3, 1, 'test@user.com');
+
+INSERT INTO acl_class (id, class) VALUES 
+(1, 'com.baeldung.lss.model.Possession');
+
+INSERT INTO acl_object_identity (id, object_id_class, object_id_identity, parent_object, owner_sid, entries_inheriting) VALUES
+(1, 1, 1, NULL, 1, 1), -- Eugen Possession object identity
+(2, 1, 2, NULL, 1, 1), -- Common Possession object identity
+(3, 1, 3, NULL, 2, 1), -- Eric Possession object identity
+(4, 1, 4, NULL, 3, 1); -- Test Possession object identity
+
+INSERT INTO acl_entry (id, acl_object_identity, ace_order, sid, mask, granting, audit_success, audit_failure) VALUES
+(1, 1, 0, 1, 16, 1, 0, 0), -- eugen@email.com has Admin permission for Eugen Possession 
+(2, 2, 0, 1, 16, 1, 0, 0), -- eugen@email.com has Admin permission for Common Possession
+(3, 2, 1, 2, 1, 1, 0, 0),  -- eric@email.com has Read permission for Common Possession 
+(4, 3, 0, 2, 16, 1, 0, 0), -- eric@email.com has Admin permission for Eric Possession
+(5, 4, 0, 3, 16, 1, 0, 0); -- test@user.com has Admin permission for Eric Possession

--- a/m11-lesson3/src/main/resources/schema-mysql.sql
+++ b/m11-lesson3/src/main/resources/schema-mysql.sql
@@ -1,0 +1,64 @@
+USE lss114;
+
+DROP TABLE IF EXISTS possession;
+DROP TABLE IF EXISTS users;
+DROP TABLE IF EXISTS acl_entry;
+DROP TABLE IF EXISTS acl_object_identity;
+DROP TABLE IF EXISTS acl_class;
+DROP TABLE IF EXISTS acl_sid;
+
+
+CREATE TABLE acl_sid (
+    id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    principal BOOLEAN NOT NULL,
+    sid VARCHAR(100) NOT NULL,
+    UNIQUE KEY unique_acl_sid (sid, principal)
+) ENGINE=InnoDB;
+
+CREATE TABLE acl_class (
+    id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    class VARCHAR(100) NOT NULL,
+    UNIQUE KEY uk_acl_class (class)
+) ENGINE=InnoDB;
+
+CREATE TABLE acl_object_identity (
+    id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    object_id_class BIGINT UNSIGNED NOT NULL,
+    object_id_identity BIGINT NOT NULL,
+    parent_object BIGINT UNSIGNED,
+    owner_sid BIGINT UNSIGNED,
+    entries_inheriting BOOLEAN NOT NULL,
+    UNIQUE KEY uk_acl_object_identity (object_id_class, object_id_identity),
+    CONSTRAINT fk_acl_object_identity_parent FOREIGN KEY (parent_object) REFERENCES acl_object_identity (id),
+    CONSTRAINT fk_acl_object_identity_class FOREIGN KEY (object_id_class) REFERENCES acl_class (id),
+    CONSTRAINT fk_acl_object_identity_owner FOREIGN KEY (owner_sid) REFERENCES acl_sid (id)
+) ENGINE=InnoDB;
+
+CREATE TABLE acl_entry (
+    id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    acl_object_identity BIGINT UNSIGNED NOT NULL,
+    ace_order INTEGER NOT NULL,
+    sid BIGINT UNSIGNED NOT NULL,
+    mask INTEGER UNSIGNED NOT NULL,
+    granting BOOLEAN NOT NULL,
+    audit_success BOOLEAN NOT NULL,
+    audit_failure BOOLEAN NOT NULL,
+    UNIQUE KEY unique_acl_entry (acl_object_identity, ace_order),
+    CONSTRAINT fk_acl_entry_object FOREIGN KEY (acl_object_identity) REFERENCES acl_object_identity (id),
+    CONSTRAINT fk_acl_entry_acl FOREIGN KEY (sid) REFERENCES acl_sid (id)
+) ENGINE=InnoDB;
+
+--
+
+CREATE TABLE users (
+  id bigint(20) NOT NULL AUTO_INCREMENT PRIMARY KEY,
+  email varchar(255) DEFAULT NULL,
+  password varchar(255) DEFAULT NULL
+) ENGINE=InnoDB;
+
+CREATE TABLE possession (
+  id bigint(20) NOT NULL AUTO_INCREMENT PRIMARY KEY,
+  name varchar(255) DEFAULT NULL,
+  owner_id bigint(20) NOT NULL,
+  CONSTRAINT fk_possession_owner FOREIGN KEY (owner_id) REFERENCES users (id)
+) ENGINE=InnoDB;

--- a/m11-lesson3/src/test/resources/application.properties
+++ b/m11-lesson3/src/test/resources/application.properties
@@ -1,0 +1,32 @@
+# Allow Thymeleaf templates to be reloaded at dev time
+#spring.thymeleaf.cache=false
+#server.tomcat.access-log-enabled=true
+#server.tomcat.basedir=target/tomcat
+server.port=8081
+
+# Hibernate
+spring.jpa.hibernate.ddl-auto=update
+
+# Persistence
+spring.jpa.properties.javax.persistence.validation.mode=none
+spring.jpa.open-in-view=false
+
+#spring.datasource.url=jdbc:mysql://localhost:3306/lss114?createDatabaseIfNotExist=true
+#spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+#spring.datasource.username=tutorialuser
+#spring.datasource.password=tutorialmy5ql
+
+spring.sql.init.mode=always
+spring.datasource.url=jdbc:hsqldb:mem:lss114
+spring.datasource.driver-class-name=org.hsqldb.jdbcDriver
+spring.datasource.username=sa
+spring.datasource.password=
+spring.sql.init.platform=hsqldb
+
+# Mail
+spring.mail.host=smtp.gmail.com
+spring.mail.port=465
+spring.mail.username=TODO
+spring.mail.password=TODO
+spring.mail.protocol=smtps
+support.email=mazarin.lss.test@gmail.com


### PR DESCRIPTION
Module 11 - Spring Security Core - ACL with Spring Security

 1. Added ACl (Access Control List) with Spring Security to protect domain objects and allow users to grant access to read or be an admin of the specific entity user-owned

 Works with Java 11, but needs workaround with java17 because there is an error with encapsulated packages due to the module architecture of Java (--add-opens did not help)