### PR TITLE
Module 3 - Spring Security OAuth - OAuth2 Beyond the Basics - The Resource Server

### DIFF
--- a/accessing-token-authentication-attributes-spel-start/accessing-token-authentication-attributes-spel-start--resource-server/src/main/java/com/baeldung/lsso/spring/ResourceSecurityConfig.java
+++ b/accessing-token-authentication-attributes-spel-start/accessing-token-authentication-attributes-spel-start--resource-server/src/main/java/com/baeldung/lsso/spring/ResourceSecurityConfig.java
@@ -3,9 +3,12 @@ package com.baeldung.lsso.spring;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
+import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.web.SecurityFilterChain;
 
+@EnableMethodSecurity
 @Configuration
 public class ResourceSecurityConfig {
 

--- a/accessing-token-authentication-attributes-spel-start/accessing-token-authentication-attributes-spel-start--resource-server/src/main/java/com/baeldung/lsso/web/controller/UserInfoController.java
+++ b/accessing-token-authentication-attributes-spel-start/accessing-token-authentication-attributes-spel-start--resource-server/src/main/java/com/baeldung/lsso/web/controller/UserInfoController.java
@@ -3,7 +3,9 @@ package com.baeldung.lsso.web.controller;
 import java.util.Collections;
 import java.util.Map;
 
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -11,10 +13,14 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 public class UserInfoController {
     
-    @GetMapping("/user/info")
-    public Map<String, Object> getUserInfo(Authentication authentication) {
-        Jwt jwt = (Jwt) authentication.getPrincipal();
+    @GetMapping("/user/info/spel1")
+    public Map<String, Object> getUserInfo(@AuthenticationPrincipal(expression = "claims") Map<String, Object> claims) {
+        return Collections.singletonMap("token", claims.get("preferred_username"));
+    }
 
-        return Collections.singletonMap("token", jwt);
+    @PreAuthorize(value = "principal?.claims['scope']?.contains('read')")
+    @GetMapping("/user/info/spel2")
+    public Map<String, Object> getReadScopeResponse() {
+        return Collections.singletonMap("response", "users with the read scope can see this");
     }
 }

--- a/accessing-token-authentication-attributes-start/accessing-token-authentication-attributes-start--resource-server/src/main/java/com/baeldung/lsso/web/controller/UserInfoController.java
+++ b/accessing-token-authentication-attributes-start/accessing-token-authentication-attributes-start--resource-server/src/main/java/com/baeldung/lsso/web/controller/UserInfoController.java
@@ -1,7 +1,11 @@
 package com.baeldung.lsso.web.controller;
 
+import java.util.Collections;
 import java.util.Map;
 
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -9,8 +13,14 @@ import org.springframework.web.bind.annotation.RestController;
 public class UserInfoController {
 
     @GetMapping("/user/info")
-    public Map<String, Object> getUserInfo() {
+    public Map<String, Object> getUserInfo(Authentication authentication) {
+        Jwt jwt = (Jwt) authentication.getPrincipal();
+        return Collections.singletonMap("token", jwt);
+    }
 
-        return null;
+    @GetMapping("/user/info/direct")
+    public Map<String, Object> getDirectUserInfo(@AuthenticationPrincipal Jwt principal) {
+        String username = (String) principal.getClaims().get("preferred_username");
+        return Collections.singletonMap("username", username);
     }
 }

--- a/basic-authorization-start/basic-authorization-start--resource-server/src/main/java/com/baeldung/lsso/spring/ResourceSecurityConfig.java
+++ b/basic-authorization-start/basic-authorization-start--resource-server/src/main/java/com/baeldung/lsso/spring/ResourceSecurityConfig.java
@@ -2,6 +2,7 @@ package com.baeldung.lsso.spring;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.web.SecurityFilterChain;
@@ -13,6 +14,7 @@ public class ResourceSecurityConfig {
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {// @formatter:off
         http.authorizeHttpRequests(authorize -> authorize
+                .requestMatchers(HttpMethod.GET, "/api/projects/**").hasAuthority("SCOPE_read")
 	              .anyRequest()
 	                .authenticated())
               .oauth2ResourceServer()

--- a/basic-authorization-start/basic-authorization-start--resource-server/src/main/java/com/baeldung/lsso/web/controller/ProjectController.java
+++ b/basic-authorization-start/basic-authorization-start--resource-server/src/main/java/com/baeldung/lsso/web/controller/ProjectController.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.Objects;
 
 import org.springframework.http.HttpStatus;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -30,6 +31,7 @@ public class ProjectController {
         this.projectService = projectService;
     }
 
+    @PreAuthorize("hasAuthority('SCOPE_email')")
     @GetMapping(value = "/{id}")
     public ProjectDto findOne(@PathVariable Long id) {
         Project entity = projectService.findById(id)

--- a/custom-authorities-from-jwt-claims-start/custom-authorities-from-jwt-claims-start--resource-server/src/main/java/com/baeldung/lsso/spring/CustomAuthoritiesExtractor.java
+++ b/custom-authorities-from-jwt-claims-start/custom-authorities-from-jwt-claims-start--resource-server/src/main/java/com/baeldung/lsso/spring/CustomAuthoritiesExtractor.java
@@ -1,0 +1,24 @@
+package com.baeldung.lsso.spring;
+
+import java.util.Collection;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.server.resource.authentication.JwtGrantedAuthoritiesConverter;
+
+public class CustomAuthoritiesExtractor implements Converter<Jwt, Collection<GrantedAuthority>> {
+
+  @Override
+  public Collection<GrantedAuthority> convert(Jwt source) {
+    JwtGrantedAuthoritiesConverter jwtGrantedAuthoritiesConverter = new JwtGrantedAuthoritiesConverter();
+    jwtGrantedAuthoritiesConverter.setAuthorityPrefix("SCOPE_"); // can be change if needed
+    jwtGrantedAuthoritiesConverter.setAuthoritiesClaimName("scope"); // usually this is common name for scopes
+    Collection<GrantedAuthority> authorities = jwtGrantedAuthoritiesConverter.convert(source);
+    String username = source.getClaimAsString("preferred_username");
+    if (username.contains("@")) {
+      authorities.add(new SimpleGrantedAuthority("EMAIL_USERNAME"));
+    }
+    return authorities;
+  }
+}

--- a/custom-authorities-from-jwt-claims-start/custom-authorities-from-jwt-claims-start--resource-server/src/main/java/com/baeldung/lsso/spring/ResourceSecurityConfig.java
+++ b/custom-authorities-from-jwt-claims-start/custom-authorities-from-jwt-claims-start--resource-server/src/main/java/com/baeldung/lsso/spring/ResourceSecurityConfig.java
@@ -1,9 +1,13 @@
 package com.baeldung.lsso.spring;
 
+import static org.springframework.security.authorization.AuthorityAuthorizationManager.hasAuthority;
+import static org.springframework.security.authorization.AuthorizationManagers.allOf;
+
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter;
 import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
@@ -13,7 +17,7 @@ public class ResourceSecurityConfig {
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {// @formatter:off
         http.authorizeHttpRequests(authorize -> authorize
 	              .requestMatchers(HttpMethod.GET, "/api/projects/**")
-	                .hasAuthority("SCOPE_read")
+	                .access(allOf(hasAuthority("SCOPE_read"), hasAuthority("EMAIL_USERNAME")))
 	              .requestMatchers(HttpMethod.POST, "/api/projects")
 	                .hasAuthority("SCOPE_write")
 	              .anyRequest()
@@ -22,5 +26,12 @@ public class ResourceSecurityConfig {
                 .jwt();
         return http.build();
     }//@formatter:on
+
+	@Bean
+	public JwtAuthenticationConverter customJwtAuthenticationConverter() {
+		JwtAuthenticationConverter jwtAuthenticationConverter = new JwtAuthenticationConverter();
+		jwtAuthenticationConverter.setJwtGrantedAuthoritiesConverter(new CustomAuthoritiesExtractor());
+		return jwtAuthenticationConverter;
+	}
 
 }

--- a/custom-authorities-from-jwt-claims-start/custom-authorities-from-jwt-claims-start--resource-server/src/main/java/com/baeldung/lsso/web/controller/ProjectController.java
+++ b/custom-authorities-from-jwt-claims-start/custom-authorities-from-jwt-claims-start--resource-server/src/main/java/com/baeldung/lsso/web/controller/ProjectController.java
@@ -6,6 +6,8 @@ import java.util.List;
 import java.util.Objects;
 
 import org.springframework.http.HttpStatus;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -45,7 +47,11 @@ public class ProjectController {
     }
 
     @GetMapping
-    public Collection<ProjectDto> findAll() {
+    public Collection<ProjectDto> findAll(Authentication authentication) {
+        // print all authorities to the console
+        Collection<? extends GrantedAuthority> authorities = authentication.getAuthorities();
+        authorities.forEach(System.out::println);
+
         Iterable<Project> projects = this.projectService.findAll();
         List<ProjectDto> projectDtos = new ArrayList<>();
         projects.forEach(p -> projectDtos.add(convertToDto(p)));

--- a/custom-validators-for-jwt-claims-start/custom-validators-for-jwt-claims-start--resource-server/src/main/java/com/baeldung/lsso/spring/CustomUsernameClaimValidator.java
+++ b/custom-validators-for-jwt-claims-start/custom-validators-for-jwt-claims-start--resource-server/src/main/java/com/baeldung/lsso/spring/CustomUsernameClaimValidator.java
@@ -1,0 +1,26 @@
+package com.baeldung.lsso.spring;
+
+import static java.util.Objects.nonNull;
+
+import org.springframework.security.oauth2.core.OAuth2Error;
+import org.springframework.security.oauth2.core.OAuth2TokenValidator;
+import org.springframework.security.oauth2.core.OAuth2TokenValidatorResult;
+import org.springframework.security.oauth2.jwt.Jwt;
+
+public class CustomUsernameClaimValidator implements OAuth2TokenValidator<Jwt> {
+
+  private static final String ALLOWED_DOMAIN = "@test.com";
+  private static final String CUSTOM_CLAIM_NAME = "preferred_username";
+  private static final String USERNAME_CLAIM_ERR_MSG = "Only @test.com users are allowed access";
+  private static final String ACCESS_DENIED  = "access_denied";
+
+  @Override
+  public OAuth2TokenValidatorResult validate(Jwt token) {
+    String username = token.getClaimAsString(CUSTOM_CLAIM_NAME);
+    if (nonNull(username) && username.toLowerCase().contains(ALLOWED_DOMAIN)) {
+      return OAuth2TokenValidatorResult.success();
+    }
+    return OAuth2TokenValidatorResult
+        .failure(new OAuth2Error(ACCESS_DENIED, USERNAME_CLAIM_ERR_MSG,null));
+  }
+}

--- a/custom-validators-for-jwt-claims-start/custom-validators-for-jwt-claims-start--resource-server/src/main/java/com/baeldung/lsso/spring/ResourceSecurityConfig.java
+++ b/custom-validators-for-jwt-claims-start/custom-validators-for-jwt-claims-start--resource-server/src/main/java/com/baeldung/lsso/spring/ResourceSecurityConfig.java
@@ -1,13 +1,26 @@
 package com.baeldung.lsso.spring;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.oauth2.core.DelegatingOAuth2TokenValidator;
+import org.springframework.security.oauth2.core.OAuth2TokenValidator;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.JwtValidators;
+import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
 import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
 public class ResourceSecurityConfig {
+
+	@Value("${spring.security.oauth2.resourceserver.jwt.jwk-set-uri}")
+	private String jwkSetUri;
+
+	@Value("${spring.security.oauth2.resourceserver.jwt.issuer-uri}")
+	private String issuer;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {// @formatter:off
@@ -22,5 +35,15 @@ public class ResourceSecurityConfig {
                 .jwt();
         return http.build();
     }//@formatter:on
+
+	@Bean
+	public JwtDecoder jwtDecoder() {
+		NimbusJwtDecoder jwtDecoder = NimbusJwtDecoder.withJwkSetUri(jwkSetUri).build();
+		OAuth2TokenValidator<Jwt> defaultValidators = JwtValidators.createDefaultWithIssuer(issuer);
+		DelegatingOAuth2TokenValidator<Jwt> validators =
+				new DelegatingOAuth2TokenValidator<>(defaultValidators, new CustomUsernameClaimValidator());
+		jwtDecoder.setJwtValidator(validators);
+		return jwtDecoder;
+	}
 
 }

--- a/multi-tenancy-support-start/multi-tenancy-support-start--resource-server/src/main/java/com/baeldung/lsso/LssoResourceServerApp.java
+++ b/multi-tenancy-support-start/multi-tenancy-support-start--resource-server/src/main/java/com/baeldung/lsso/LssoResourceServerApp.java
@@ -1,8 +1,11 @@
 package com.baeldung.lsso;
 
+import com.baeldung.lsso.spring.AuthServerConfig;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 
+@EnableConfigurationProperties(AuthServerConfig.class)
 @SpringBootApplication
 public class LssoResourceServerApp {
 

--- a/multi-tenancy-support-start/multi-tenancy-support-start--resource-server/src/main/java/com/baeldung/lsso/spring/AuthServerConfig.java
+++ b/multi-tenancy-support-start/multi-tenancy-support-start--resource-server/src/main/java/com/baeldung/lsso/spring/AuthServerConfig.java
@@ -1,0 +1,51 @@
+package com.baeldung.lsso.spring;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "oauth2")
+public class AuthServerConfig {
+
+  private final Map<String, String> issuersJwkSetUri = new HashMap<>();
+
+  public AuthServerConfig(Map<String, AuthServer> authServers) {
+    authServers
+        .values()
+        .forEach(authServer ->
+            issuersJwkSetUri.put(authServer.getIssuerUri(), authServer.getJwkSetUrl()));
+  }
+
+  public Map<String, String> getIssuersJwkSetUri() {
+    return issuersJwkSetUri;
+  }
+
+  public Set<String> getTrustedIssuerUris() {
+    return issuersJwkSetUri.keySet();
+  }
+
+  public static class AuthServer {
+    private String jwkSetUrl;
+    private String issuerUri;
+
+    public String getJwkSetUrl() {
+      return jwkSetUrl;
+    }
+
+    public void setJwkSetUrl(String jwkSetUrl) {
+      this.jwkSetUrl = jwkSetUrl;
+    }
+
+    public String getIssuerUri() {
+      return issuerUri;
+    }
+
+    public void setIssuerUri(String issuerUri) {
+      this.issuerUri = issuerUri;
+    }
+  }
+
+
+
+}

--- a/multi-tenancy-support-start/multi-tenancy-support-start--resource-server/src/main/java/com/baeldung/lsso/spring/ResourceSecurityConfig.java
+++ b/multi-tenancy-support-start/multi-tenancy-support-start--resource-server/src/main/java/com/baeldung/lsso/spring/ResourceSecurityConfig.java
@@ -1,13 +1,26 @@
 package com.baeldung.lsso.spring;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
+import org.springframework.security.authentication.ProviderManager;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.oauth2.jose.jws.SignatureAlgorithm;
+import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationProvider;
+import org.springframework.security.oauth2.server.resource.authentication.JwtIssuerAuthenticationManagerResolver;
 import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
 public class ResourceSecurityConfig {
+
+	private final AuthServerConfig authServerConfig;
+
+	@Autowired
+	public ResourceSecurityConfig(AuthServerConfig authServerConfig) {
+		this.authServerConfig = authServerConfig;
+	}
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {// @formatter:off
@@ -18,9 +31,21 @@ public class ResourceSecurityConfig {
 	                .hasAuthority("SCOPE_write")
 	              .anyRequest()
 	                .authenticated())
-              .oauth2ResourceServer()
-                .jwt();
+              .oauth2ResourceServer(rs ->
+									rs.authenticationManagerResolver(jwtIssuerAuthenticationManagerResolver()));
         return http.build();
     }//@formatter:on
+
+	@Bean
+	public JwtIssuerAuthenticationManagerResolver jwtIssuerAuthenticationManagerResolver() {
+    return new JwtIssuerAuthenticationManagerResolver(issuer -> {
+			NimbusJwtDecoder jwtDecoder = NimbusJwtDecoder
+					.withJwkSetUri(authServerConfig.getIssuersJwkSetUri().get(issuer))
+					.jwsAlgorithm(SignatureAlgorithm.RS256)
+					.build();
+			var authProvider = new JwtAuthenticationProvider(jwtDecoder);
+			return new ProviderManager(authProvider);
+		});
+	}
 
 }

--- a/multi-tenancy-support-start/multi-tenancy-support-start--resource-server/src/main/resources/application.yml
+++ b/multi-tenancy-support-start/multi-tenancy-support-start--resource-server/src/main/resources/application.yml
@@ -4,13 +4,16 @@ server:
     context-path: /lsso-resource-server
 
 ####### resource server configuration properties
+oauth2:
+  auth-servers:
+    baeldung:
+        issuer-uri: http://localhost:8083/auth/realms/baeldung
+        jwk-set-url: http://localhost:8083/auth/realms/baeldung/protocol/openid-connect/certs
+    tenant2:
+        issuer-uri: http://localhost:8084/auth/realms/tenant2
+        jwk-set-url: http://localhost:8084/auth/realms/tenant2/protocol/openid-connect/certs
+
 spring:
-  security:
-    oauth2:
-      resourceserver:
-        jwt:
-          issuer-uri: http://localhost:8083/auth/realms/baeldung
-          jwk-set-uri: http://localhost:8083/auth/realms/baeldung/protocol/openid-connect/certs
   datasource:
     username: sa
     url: jdbc:h2:mem:testdb;DB_CLOSE_ON_EXIT=FALSE;

--- a/resource-server-testing-support-start/resource-server-testing-support-start--resource-server/src/test/java/com/baeldung/lsso/ResourceServerTestingSupportIntegrationTest.java
+++ b/resource-server-testing-support-start/resource-server-testing-support-start--resource-server/src/test/java/com/baeldung/lsso/ResourceServerTestingSupportIntegrationTest.java
@@ -1,8 +1,25 @@
 package com.baeldung.lsso;
 
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.baeldung.lsso.spring.CustomAuthoritiesConverter;
+import com.baeldung.lsso.web.dto.ProjectDto;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.Duration;
+import java.time.Instant;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.test.web.servlet.MockMvc;
 
 @SpringBootTest
@@ -12,5 +29,97 @@ public class ResourceServerTestingSupportIntegrationTest {
     @Autowired
     private MockMvc mvc;
 
+
+    @Test
+    public void test_receivedProjects_whenGivenJwtToken_thenIsOk() throws Exception {
+        mvc.perform(get("/api/projects").with(jwt()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.size()", Matchers.greaterThan(0)))
+            .andExpect(jsonPath("$..name", Matchers.hasItems("Project 1", "Project 2")));
+    }
+
+    @Test
+    public void test_createProject_whenJwtScopeIsNotCorrect_thenIsForbidden() throws Exception {
+        mvc.perform(
+            post("/api/projects")
+                .with(jwt())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(getTestProjectBody()))
+            .andExpect(status().isForbidden());
+    }
+
+    @Test
+    public void test_createProject_whenJwtWithCorrectScope_thenIsOK() throws Exception {
+        ProjectDto projectDto = buildTestProject();
+        mvc.perform(
+                post("/api/projects")
+                    .with(jwt().jwt(jwtBuilder -> jwtBuilder.claim("scope", "write")))
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(getTestProjectBody(projectDto)))
+            .andExpect(status().isCreated());
+
+        checkCreatedProjects(projectDto);
+    }
+
+    @Test
+    public void test_createProjectWithCustomJwtConverter_whenJwtWithAdminSubject_thenIsOK() throws Exception {
+        ProjectDto projectDto = buildTestProject();
+        mvc.perform(
+                post("/api/projects")
+                    .with(
+                        jwt()
+                            .jwt(jwtBuilder -> jwtBuilder.subject("admin"))
+                            .authorities(new CustomAuthoritiesConverter())
+                    )
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(getTestProjectBody(projectDto)))
+            .andExpect(status().isCreated());
+
+        checkCreatedProjects(projectDto);
+    }
+
+    @Test
+    public void test_createProjectDirectlyWithAuthorities_whenJwtWithAdminSubject_thenIsOK() throws Exception {
+        ProjectDto projectDto = buildTestProject();
+        mvc.perform(
+                post("/api/projects")
+                    .with(
+                        jwt().authorities(new SimpleGrantedAuthority("SCOPE_write"))
+                    )
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(getTestProjectBody(projectDto)))
+            .andExpect(status().isCreated());
+
+        checkCreatedProjects(projectDto);
+    }
+
+    @Test
+    public void test_getProjects_whenTokenIsExpired_thenBypassSecurityToTestTheLogic() throws Exception {
+        mvc.perform(get("/api/projects")
+                .with(jwt().jwt(jwtBuilder ->
+                    jwtBuilder.expiresAt(Instant.now().minus(Duration.ofDays(5L))))))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.size()", Matchers.greaterThan(0)))
+            .andExpect(jsonPath("$..name", Matchers.hasItems("Project 1", "Project 2")));
+    }
+
+    private void checkCreatedProjects(ProjectDto projectDto) throws Exception {
+        mvc.perform(get("/api/projects").with(jwt()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.size()", Matchers.greaterThan(3)))
+            .andExpect(jsonPath("$..name", Matchers.hasItems(projectDto.name())));
+    }
+
+    private static String getTestProjectBody() throws JsonProcessingException {
+        return new ObjectMapper().writeValueAsString(buildTestProject());
+    }
+
+    private static String getTestProjectBody(ProjectDto projectDto) throws JsonProcessingException {
+        return new ObjectMapper().writeValueAsString(projectDto);
+    }
+
+    private static ProjectDto buildTestProject() {
+        return new ProjectDto(4L, "New Project 4", null);
+    }
 
 }

--- a/verify-validate-claims-jwt/verify-validate-claims-jwt--resource-server/src/main/resources/application.yml
+++ b/verify-validate-claims-jwt/verify-validate-claims-jwt--resource-server/src/main/resources/application.yml
@@ -9,7 +9,7 @@ spring:
     oauth2:
       resourceserver:
         jwt:
-          issuer-uri: http://localhost:8083/auth/realms/baeldung
+#          issuer-uri: http://localhost:8083/auth/realms/baeldung
           jwk-set-uri: http://localhost:8083/auth/realms/baeldung/protocol/openid-connect/certs
   devtools:
     livereload:


### PR DESCRIPTION
Module 3 - Spring Security OAuth - OAuth2 Beyond the Basics - The Resource Server

1. Basic Authorization with OAuth2 (protect the resource)
2. Validate claims using NimbusJwtDecoder with default two JWT Validators (JwtTimestampValidator, JwtIssuerValidator) or by just providing the DelegatingOAuth2TokenValidator with a list of validators and declaring as a bean for the jwtDecoder to pick it up.
3. Accessing the JWT Bearer Token using the Authorization object or the Principal object with @AuthenticationPrincipal annotation.
4. Providing custom authorities converter by declaring JwtAuthenticationConverter bean and setting the custom JwtGrantedAuthoritiesConverter that implements Converter<Jwt, Collection<GrantedAuthority>>.
5. Providing custom JWT validators using default ones DelegatingOAuth2TokenValidator with custom created validators that implements OAuth2TokenValidator<Jwt>.
6. Configuring the multi-tenancy in Spring Security Resource Server by replacing default security properties for auth servers with custom ones and configuring the oauth2ResourceServer with JwtIssuerAuthenticationManagerResolver with the provided correct issuer.
7. Testing the logic with mockMvc bypassing the spring security with configured jwt(), authorities() in the provided request using mockMvc.