### PR TITLE
Module 4 - Spring Security OAuth2 - OAuth2 Beyond the Basics - The Client

### DIFF
--- a/oauth2-social-login-start/oauth2-social-login-start--client/src/main/java/com/baeldung/lsso/controller/UserProfileController.java
+++ b/oauth2-social-login-start/oauth2-social-login-start--client/src/main/java/com/baeldung/lsso/controller/UserProfileController.java
@@ -1,0 +1,44 @@
+package com.baeldung.lsso.controller;
+
+import java.util.List;
+import java.util.Map;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.servlet.ModelAndView;
+
+@Controller
+public class UserProfileController {
+
+  private WebClient webClient;
+
+  @Autowired
+  public UserProfileController(WebClient webClient) {
+    this.webClient = webClient;
+  }
+
+  @GetMapping("/user")
+  public String welcomePage(Model model, @AuthenticationPrincipal OAuth2User principal) {
+    model.addAttribute("name", principal.getAttribute("name"));
+    model.addAttribute("id", principal.getAttribute("login"));
+    model.addAttribute("img", principal.getAttribute("avatar_url"));
+    String reposUrl = principal.getAttribute("repos_url");
+    model.addAttribute("repos", getRepositories(reposUrl));
+    return "user";
+  }
+
+  private List<Map<Object, Object>> getRepositories(String reposUrl) {
+    return this.webClient
+        .get()
+        .uri(reposUrl)
+        .retrieve()
+        .bodyToMono(new ParameterizedTypeReference<List<Map<Object, Object>>>() {})
+        .block();
+  }
+
+}

--- a/oauth2-social-login-start/oauth2-social-login-start--client/src/main/java/com/baeldung/lsso/spring/ClientSecurityConfig.java
+++ b/oauth2-social-login-start/oauth2-social-login-start--client/src/main/java/com/baeldung/lsso/spring/ClientSecurityConfig.java
@@ -1,31 +1,70 @@
 package com.baeldung.lsso.spring;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.oauth2.client.oidc.web.logout.OidcClientInitiatedLogoutSuccessHandler;
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
 import org.springframework.security.oauth2.client.web.OAuth2AuthorizedClientRepository;
 import org.springframework.security.oauth2.client.web.reactive.function.client.ServletOAuth2AuthorizedClientExchangeFilterFunction;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.logout.LogoutSuccessHandler;
 import org.springframework.web.reactive.function.client.WebClient;
 
 @Configuration
 public class ClientSecurityConfig {
 
-    @Bean
-    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {// @formatter:off
+
+  private final ClientRegistrationRepository clientRegistrationRepository;
+
+  @Autowired
+  public ClientSecurityConfig(ClientRegistrationRepository clientRegistrationRepository) {
+    this.clientRegistrationRepository = clientRegistrationRepository;
+  }
+
+  @Bean
+  public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {// @formatter:off
         http.authorizeHttpRequests(authorize -> authorize
 	            .requestMatchers("/").permitAll()
-	            .anyRequest().authenticated());
+	            .anyRequest().authenticated())
+            .oauth2Login()
+            .and()
+            .logout(logout -> logout
+                .logoutSuccessHandler(oidcLogoutSuccessHandler())
+                .invalidateHttpSession(true)
+                .clearAuthentication(true)
+                .deleteCookies("JSESSIONID")
+            );
         return http.build();
     }// @formatter:on
 
-    //@Bean
-    WebClient webClient(ClientRegistrationRepository clientRegistrationRepository, OAuth2AuthorizedClientRepository authorizedClientRepository) {
-        ServletOAuth2AuthorizedClientExchangeFilterFunction oauth2 = new ServletOAuth2AuthorizedClientExchangeFilterFunction(clientRegistrationRepository, authorizedClientRepository);
-        oauth2.setDefaultOAuth2AuthorizedClient(true);
-        return WebClient.builder()
-            .apply(oauth2.oauth2Configuration())
-            .build();
-    }
+
+  // todo investigate this later. How to logout user from GitHub provider.
+  // Doesn't work because:
+  // 1. by default spring security creates DefaultOAuth2User
+  // using oauth2 classes, but the logout handler works only for DefaultOidcUser's that implement OidcUser and
+  // DefaultOauth2User is not OidcUser.
+  // 2. GitHub doesn't provide the well-known endpoint and maybe doesn't provide end_session_endpoint
+  // and so can't support RP-Initiated Logout flow
+  // 3. GitHub not supported Open id connect.
+  // https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/authorizing-oauth-apps
+  // 4. Also they not support PKCE https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/authorizing-oauth-apps
+  private LogoutSuccessHandler oidcLogoutSuccessHandler() {
+    OidcClientInitiatedLogoutSuccessHandler oidcLogoutSuccessHandler =
+        new OidcClientInitiatedLogoutSuccessHandler(this.clientRegistrationRepository);
+    oidcLogoutSuccessHandler.setPostLogoutRedirectUri("{baseUrl}");
+    return oidcLogoutSuccessHandler;
+  }
+
+  @Bean
+  WebClient webClient(ClientRegistrationRepository clientRegistrationRepository,
+      OAuth2AuthorizedClientRepository authorizedClientRepository) {
+    ServletOAuth2AuthorizedClientExchangeFilterFunction oauth2 = new ServletOAuth2AuthorizedClientExchangeFilterFunction(
+        clientRegistrationRepository, authorizedClientRepository);
+    oauth2.setDefaultOAuth2AuthorizedClient(true);
+    return WebClient.builder()
+        .apply(oauth2.oauth2Configuration())
+        .build();
+  }
 }

--- a/oauth2-social-login-start/oauth2-social-login-start--client/src/main/resources/application.yml
+++ b/oauth2-social-login-start/oauth2-social-login-start--client/src/main/resources/application.yml
@@ -1,6 +1,14 @@
 spring:
   thymeleaf:
     cache: false
+  security:
+    oauth2:
+      client:
+        registration:
+          github:
+            scope: user:email, read:user
+            client-id: 0b6c373a600c4856b03d
+            client-secret: e66c3d38ae3f5d13580eff6d38fe2fffc7f249de
     
 server: 
   port: 8082
@@ -10,4 +18,3 @@ server:
 logging: 
   level: 
     org.springframework: INFO
-        

--- a/oauth2-social-login-start/oauth2-social-login-start--client/src/main/resources/templates/user.html
+++ b/oauth2-social-login-start/oauth2-social-login-start--client/src/main/resources/templates/user.html
@@ -7,7 +7,7 @@
 </head>
 <body>
     <nav class="navbar navbar-expand-lg navbar-light bg-light shadow-sm p-3 mb-5">
-        <a class="navbar-brand" th:href="@{/user/}">Baeldung OAuth2 Github Client</a>
+        <a class="navbar-brand" th:href="@{/user}">Baeldung OAuth2 Github Client</a>
         <ul class="navbar-nav ml-auto">
             <li class="navbar-text">Hi, <span th:text="${name}"></span>&nbsp;&nbsp;&nbsp;
             </li>
@@ -15,23 +15,30 @@
         </ul>
     </nav>
     <div class="container">
-        <h1>Welcome!!</h1>
+        <h1>Welcome</h1>
         
         <div class="row">
             <div class="col-sm-2">
                 <div>
                     <!-- Profile Image -->
-                    <img class="img-thumbnail" width="100" height="100"/>
+                    <img th:src="@{${img}}" class="img-thumbnail" width="100" height="100"/>
                 </div>
             </div>
             <div class="col">
             <!-- Basic Attributes -->
+                Name: <span th:text="${name}"></span>
+                <br>
+                User id: <span th:text="${id}"></span>
             </div>
         </div>
         <div class="row">
             <div class="col">
                 <div>
                 <!-- Repos -->
+                    <h4>User Repositories</h4>
+                    <div th:each="repo : ${repos}">
+                        <p th:text="${repo.name}"></p>
+                    </div>
                 </div>
             </div>
         </div>

--- a/testing-oauth2-clients-start/testing-oauth2-clients-start--client/pom.xml
+++ b/testing-oauth2-clients-start/testing-oauth2-clients-start--client/pom.xml
@@ -69,6 +69,12 @@
             <artifactId>rest-assured</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>mockwebserver</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/testing-oauth2-clients-start/testing-oauth2-clients-start--client/src/main/java/com/baeldung/lsso/web/controller/ProjectClientController.java
+++ b/testing-oauth2-clients-start/testing-oauth2-clients-start--client/src/main/java/com/baeldung/lsso/web/controller/ProjectClientController.java
@@ -8,6 +8,9 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClient;
+import org.springframework.security.oauth2.client.annotation.RegisteredOAuth2AuthorizedClient;
+import org.springframework.security.oauth2.client.web.reactive.function.client.ServletOAuth2AuthorizedClientExchangeFilterFunction;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
@@ -31,6 +34,22 @@ public class ProjectClientController {
     public String getProjects(Model model) {
         List<ProjectModel> projects = this.webClient.get()
             .uri(projectApiUrl)
+            .retrieve()
+            .bodyToMono(new ParameterizedTypeReference<List<ProjectModel>>() {
+            })
+            .block();
+        model.addAttribute("projects", projects);
+        return "projects";
+    }
+
+    @GetMapping("/projects/just/test")
+    public String getProjectsToTest(
+        @RegisteredOAuth2AuthorizedClient("custom") OAuth2AuthorizedClient oAuth2AuthorizedClient,
+        Model model) {
+        List<ProjectModel> projects = this.webClient.get()
+            .uri(projectApiUrl)
+            .attributes(ServletOAuth2AuthorizedClientExchangeFilterFunction
+                .oauth2AuthorizedClient(oAuth2AuthorizedClient))
             .retrieve()
             .bodyToMono(new ParameterizedTypeReference<List<ProjectModel>>() {
             })

--- a/testing-oauth2-clients-start/testing-oauth2-clients-start--client/src/test/java/com/baeldung/lsso/OAuth2ClientIntegrationTest.java
+++ b/testing-oauth2-clients-start/testing-oauth2-clients-start--client/src/test/java/com/baeldung/lsso/OAuth2ClientIntegrationTest.java
@@ -1,8 +1,29 @@
 package com.baeldung.lsso;
 
+import static org.hamcrest.Matchers.containsString;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.oauth2Login;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.xpath;
+
+import java.util.Map;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 
 @SpringBootTest
@@ -11,5 +32,71 @@ public class OAuth2ClientIntegrationTest {
 
     @Autowired
     private MockMvc mvc;
+
+    private static MockWebServer resourceServer;
+
+    @BeforeAll
+    public static void startServers() throws Exception {
+        resourceServer = new MockWebServer();
+        resourceServer.start(8081);
+    }
+
+    @AfterAll
+    public static void tearDown() throws Exception {
+        resourceServer.shutdown();
+    }
+
+    @Test
+    @WithMockUser
+    void givenMockedUser_whenRequestResources_thenOK() throws Exception {
+        String mockedResources = "[{\"id\":1,\"name\":\"Project 1\",\"dateCreated\":\"2025-06-01\"}]";
+
+        resourceServer.enqueue(new MockResponse().setBody(mockedResources)
+            .addHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE));
+
+        mvc.perform(get("/projects"))
+            .andExpect(status().isOk())
+            .andExpect(content().string(containsString("Project 1")));
+    }
+
+    @Test
+    void givenMockedUser_whenRequestResourcesWithOauth2LoginDirective_thenOK() throws Exception {
+        String mockedResources = "[{\"id\":1,\"name\":\"Project 1\",\"dateCreated\":\"2025-06-01\"}]";
+
+        resourceServer.enqueue(new MockResponse().setBody(mockedResources)
+            .addHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE));
+
+        mvc.perform(get("/projects/just/test").with(oauth2Login()))
+            .andExpect(status().isOk())
+            .andExpect(content().string(containsString("Project 1")));
+    }
+
+    @Test
+    void givenEndpointRequireEmailVerifiedAttrAndEmailScope_whenNoEmailScope_thenRouteToReqPermissionPage() throws Exception {
+        this.mvc.perform(get("/addproject").with(oauth2Login().attributes(attrs -> attrs.put("email_verified", true))))
+            .andExpect(status().isOk())
+            .andExpect(xpath("//button[@type='button']").string("Request Permission"));
+    }
+
+    @Test
+    void givenEndpointRequireEmailVerifiedAttrAndEmailScope_whenEmailNotVerified_thenRouteToVerifyEmailPage() throws Exception {
+        this.mvc.perform(get("/addproject").with(oauth2Login().authorities(new SimpleGrantedAuthority("SCOPE_email"))))
+            .andExpect(status().isOk())
+            .andExpect(xpath("//button[@type='button']").string("Go Back"));
+    }
+
+    @Test
+    void givenEndpointRequireEmailVerifiedAttrAndEmailScope_whenAllAttrsSet_thenRouteToAddProjectPage()
+        throws Exception {
+        //using customized oauth2User object
+        OAuth2User oauth2User = new DefaultOAuth2User(
+            AuthorityUtils.createAuthorityList("SCOPE_email"),
+            Map.of("email_verified", true, "username", "principal_name"),
+            "username");
+
+        mvc.perform(get("/addproject").with(oauth2Login().oauth2User(oauth2User)))
+            .andExpect(status().isOk())
+            .andExpect(xpath("//button[@type='submit']").string("Create Project"));
+    }
 
 }


### PR DESCRIPTION
Module 4 - Spring Security OAuth2 - OAuth2 Beyond the Basics - The Client

1. Creating social login (using GitHub app). GitHub doesn't support OIDC when authenticating the user and well-known discovery endpoint and PKCE, so currently logout the user from the GitHub provider is not possible for now and is marked as todo later.
2. Configured the WebClient to automatically attach the Bearer access token to the request and refresh the token using the refresh token when it needed.
3. Testing the auth client application using the mockMvc with the oauth2Login directive and OAuth2User by adding the attributes and authorities as the client copes, and using mockwebserver dependency to mock the requests to the resource server.