### PR TITLE
Module 5 - Spring Security OAuth2 - OAuth2 Beyond the Basics - Deep-Dives

### DIFF
--- a/client-credentials-flow-start/client-credentials-flow-start--client/src/main/java/com/baeldung/lsso/LssoClientApplication.java
+++ b/client-credentials-flow-start/client-credentials-flow-start--client/src/main/java/com/baeldung/lsso/LssoClientApplication.java
@@ -2,7 +2,9 @@ package com.baeldung.lsso;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
 @SpringBootApplication
 public class LssoClientApplication {
 

--- a/client-credentials-flow-start/client-credentials-flow-start--client/src/main/java/com/baeldung/lsso/scheduler/ProjectRetrieveScheduler.java
+++ b/client-credentials-flow-start/client-credentials-flow-start--client/src/main/java/com/baeldung/lsso/scheduler/ProjectRetrieveScheduler.java
@@ -1,0 +1,41 @@
+package com.baeldung.lsso.scheduler;
+
+import com.baeldung.lsso.web.model.ProjectModel;
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Component
+public class ProjectRetrieveScheduler {
+
+  private static final Logger LOG = LoggerFactory.getLogger(ProjectRetrieveScheduler.class);
+
+  @Value("${resourceserver.api.project.url:http://localhost:8081/lsso-resource-server/api/projects/}")
+  private String projectApiUrl;
+
+  private final WebClient webClient;
+
+  @Autowired
+  public ProjectRetrieveScheduler(WebClient webClient) {
+    this.webClient = webClient;
+  }
+
+  @Scheduled(fixedRate = 20000)
+  public void scheduleResourceRetrieval() {
+    List<ProjectModel> retrievedProjects = webClient
+        .get()
+        .uri(projectApiUrl)
+        .retrieve()
+        .bodyToMono(new ParameterizedTypeReference<List<ProjectModel>>() {
+        })
+        .block();
+    LOG.info("Projects in the repository: " + retrievedProjects.size());
+  }
+
+}

--- a/client-credentials-flow-start/client-credentials-flow-start--client/src/main/java/com/baeldung/lsso/spring/ClientSecurityConfig.java
+++ b/client-credentials-flow-start/client-credentials-flow-start--client/src/main/java/com/baeldung/lsso/spring/ClientSecurityConfig.java
@@ -2,6 +2,11 @@ package com.baeldung.lsso.spring;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.oauth2.client.AuthorizedClientServiceOAuth2AuthorizedClientManager;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientManager;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientProvider;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientProviderBuilder;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService;
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
 import org.springframework.security.oauth2.client.web.OAuth2AuthorizedClientRepository;
 import org.springframework.security.oauth2.client.web.reactive.function.client.ServletOAuth2AuthorizedClientExchangeFilterFunction;
@@ -10,10 +15,23 @@ import org.springframework.web.reactive.function.client.WebClient;
 @Configuration
 public class ClientSecurityConfig {
 
-    @Bean WebClient webClient(ClientRegistrationRepository clientRegistrationRepository, OAuth2AuthorizedClientRepository authorizedClientRepository) {
-        ServletOAuth2AuthorizedClientExchangeFilterFunction oauth2 = new ServletOAuth2AuthorizedClientExchangeFilterFunction(clientRegistrationRepository, authorizedClientRepository);
-        oauth2.setDefaultOAuth2AuthorizedClient(true);
-        return WebClient.builder().apply(oauth2.oauth2Configuration()).build();
-    }
+  @Bean
+  WebClient webClient(OAuth2AuthorizedClientManager manager) {
+    var oauth2ExchangeFunction = new ServletOAuth2AuthorizedClientExchangeFilterFunction(manager);
+    oauth2ExchangeFunction.setDefaultClientRegistrationId("customClientCredentials");
+    return WebClient.builder().apply(oauth2ExchangeFunction.oauth2Configuration()).build();
+  }
+
+  @Bean
+  public OAuth2AuthorizedClientManager oAuth2AuthorizedClientManager(
+      ClientRegistrationRepository clientRegistrationRepository,
+      OAuth2AuthorizedClientService oAuth2AuthorizedClientService) {
+
+    var provider = OAuth2AuthorizedClientProviderBuilder.builder().clientCredentials().build();
+    var manager = new AuthorizedClientServiceOAuth2AuthorizedClientManager(
+        clientRegistrationRepository, oAuth2AuthorizedClientService);
+    manager.setAuthorizedClientProvider(provider);
+    return manager;
+  }
 
 }

--- a/client-credentials-flow-start/client-credentials-flow-start--client/src/main/resources/application.yml
+++ b/client-credentials-flow-start/client-credentials-flow-start--client/src/main/resources/application.yml
@@ -4,7 +4,7 @@ spring:
       client:
         registration:
           customClientCredentials:
-            authorization-grant-type: /
+            authorization-grant-type: client_credentials
             client-id: lssoClient
             client-secret: lssoSecret
             scope: write, read
@@ -22,7 +22,8 @@ server:
 
 logging: 
   level:
-    org.springframework: INFO
+    org.springframework.web.client: DEBUG
+    org.springframework.web.reactive.function.client: DEBUG
 
 resourceserver:
   api:

--- a/client-credentials-flow-start/client-credentials-flow-start--resource-server/src/test/java/com/baeldung/lsso/TokenLiveTest.java
+++ b/client-credentials-flow-start/client-credentials-flow-start--resource-server/src/test/java/com/baeldung/lsso/TokenLiveTest.java
@@ -1,9 +1,42 @@
 package com.baeldung.lsso;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.baeldung.lsso.persistence.model.Project;
+import io.restassured.RestAssured;
+import io.restassured.response.Response;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+
 public class TokenLiveTest {
 
     private static final String AUTH_SERVICE_BASE_URL = "http://localhost:8083/auth/realms/baeldung";
     private static final String CONNECT_TOKEN = AUTH_SERVICE_BASE_URL + "/protocol/openid-connect/token";
     private static final String SERVER_API_PROJECTS = "http://localhost:8081/lsso-resource-server/api/projects";
 
+
+    @Test
+    public void givenClientCredentialsGrant_whenUseToken_thenSuccess() {
+        final Map<String, String> params = new HashMap<>();
+        params.put("scope", "read write");
+        params.put("grant_type", "client_credentials");
+        params.put("client_id", "lssoClient");
+        params.put("client_secret", "lssoSecret");
+
+        Response response = RestAssured.given().formParams(params).post(CONNECT_TOKEN);
+
+        String accessToken = response.jsonPath().getString("access_token");
+
+        assertThat(accessToken).isNotBlank();
+
+        response = RestAssured.given().auth().oauth2(accessToken).get(SERVER_API_PROJECTS);
+
+        assertThat(HttpStatus.OK.value()).isEqualTo(response.getStatusCode());
+
+        List<Project> projects = response.getBody().as(List.class);
+        assertThat(3).isEqualTo(projects.size());
+    }
 }

--- a/legacy-stack-authorization-server-start/legacy-stack-authorization-server-start--auth-server/pom.xml
+++ b/legacy-stack-authorization-server-start/legacy-stack-authorization-server-start--auth-server/pom.xml
@@ -23,7 +23,16 @@
         </dependency>
 
         <!-- security -->
+        <dependency>
+            <groupId>org.springframework.security.oauth.boot</groupId>
+            <artifactId>spring-security-oauth2-autoconfigure</artifactId>
+            <version>2.3.1.RELEASE</version>
+        </dependency>
 
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-oauth2-jose</artifactId>
+        </dependency>
         <!-- test -->
 
         <dependency>

--- a/legacy-stack-authorization-server-start/legacy-stack-authorization-server-start--auth-server/src/main/java/com/baeldung/lsso/LssoAuthorizationServerApp.java
+++ b/legacy-stack-authorization-server-start/legacy-stack-authorization-server-start--auth-server/src/main/java/com/baeldung/lsso/LssoAuthorizationServerApp.java
@@ -2,7 +2,9 @@ package com.baeldung.lsso;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.security.oauth2.config.annotation.web.configuration.EnableAuthorizationServer;
 
+@EnableAuthorizationServer
 @SpringBootApplication
 public class LssoAuthorizationServerApp {
 

--- a/legacy-stack-authorization-server-start/legacy-stack-authorization-server-start--auth-server/src/main/java/com/baeldung/lsso/config/JwkSetEndpoint.java
+++ b/legacy-stack-authorization-server-start/legacy-stack-authorization-server-start--auth-server/src/main/java/com/baeldung/lsso/config/JwkSetEndpoint.java
@@ -1,0 +1,33 @@
+package com.baeldung.lsso.config;
+
+import com.nimbusds.jose.jwk.JWKSet;
+import com.nimbusds.jose.jwk.RSAKey;
+import java.security.KeyPair;
+import java.security.Principal;
+import java.security.interfaces.RSAPublicKey;
+import java.util.Map;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.oauth2.provider.endpoint.FrameworkEndpoint;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+@FrameworkEndpoint
+public class JwkSetEndpoint {
+
+  private final KeyPair keyPair;
+
+  @Autowired
+  public JwkSetEndpoint(KeyPair keyPair) {
+    this.keyPair = keyPair;
+  }
+
+
+  @GetMapping("/endpoint/jwks.json")
+  @ResponseBody
+  public Map<String, Object> getKeys(Principal principal) {
+    RSAPublicKey publicKey = (RSAPublicKey) this.keyPair.getPublic();
+    RSAKey rsaKey = new RSAKey.Builder(publicKey).build();
+    return new JWKSet(rsaKey).toJSONObject();
+  }
+
+}

--- a/legacy-stack-authorization-server-start/legacy-stack-authorization-server-start--auth-server/src/main/java/com/baeldung/lsso/config/SecurityConfig.java
+++ b/legacy-stack-authorization-server-start/legacy-stack-authorization-server-start--auth-server/src/main/java/com/baeldung/lsso/config/SecurityConfig.java
@@ -1,0 +1,38 @@
+package com.baeldung.lsso.config;
+
+import java.security.KeyPair;
+import org.springframework.context.annotation.Bean;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.oauth2.provider.token.store.KeyStoreKeyFactory;
+
+@EnableWebSecurity
+public class SecurityConfig extends WebSecurityConfigurerAdapter {
+
+  @Override
+  protected void configure(HttpSecurity http) throws Exception {
+    http
+        .authorizeRequests()
+        .antMatchers("/endpoint/jwks.json").permitAll()
+        .anyRequest().authenticated()
+        .and()
+        .formLogin();
+  }
+
+  @Bean
+  public KeyPair keyPair() {
+    var keyStoreFactory = new KeyStoreKeyFactory(new ClassPathResource("mytest.jks"),
+                                                "mypass".toCharArray());
+    return keyStoreFactory.getKeyPair("mytest");
+  }
+
+  @Bean
+  public PasswordEncoder encoder() {
+    return new BCryptPasswordEncoder();
+  }
+
+}

--- a/legacy-stack-authorization-server-start/legacy-stack-authorization-server-start--auth-server/src/main/java/com/baeldung/lsso/config/resource/AuthorizationResourceServerConfig.java
+++ b/legacy-stack-authorization-server-start/legacy-stack-authorization-server-start--auth-server/src/main/java/com/baeldung/lsso/config/resource/AuthorizationResourceServerConfig.java
@@ -1,0 +1,27 @@
+package com.baeldung.lsso.config.resource;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.oauth2.config.annotation.web.configuration.EnableResourceServer;
+import org.springframework.security.oauth2.config.annotation.web.configuration.ResourceServerConfigurerAdapter;
+
+@Configuration
+@EnableResourceServer
+public class AuthorizationResourceServerConfig extends ResourceServerConfigurerAdapter {
+
+  @Override
+  public void configure(HttpSecurity http) throws Exception {
+    http
+        .sessionManagement()
+        .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+        .and()
+        .requestMatchers().antMatchers("/users/userinfo")
+
+        .and()
+
+        .authorizeRequests()
+        .antMatchers("/users/userinfo")
+        .authenticated();
+  }
+}

--- a/legacy-stack-authorization-server-start/legacy-stack-authorization-server-start--auth-server/src/main/java/com/baeldung/lsso/controller/UserInfoController.java
+++ b/legacy-stack-authorization-server-start/legacy-stack-authorization-server-start--auth-server/src/main/java/com/baeldung/lsso/controller/UserInfoController.java
@@ -1,0 +1,17 @@
+package com.baeldung.lsso.controller;
+
+import java.util.Collections;
+import java.util.Map;
+import org.springframework.security.oauth2.provider.OAuth2Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class UserInfoController {
+
+  @GetMapping("/users/userinfo")
+  public Map<String, Object> userInfo(OAuth2Authentication oAuth2Authentication) {
+    return Collections.singletonMap("preferred_username", oAuth2Authentication.getName());
+  }
+
+}

--- a/legacy-stack-authorization-server-start/legacy-stack-authorization-server-start--auth-server/src/main/resources/application.yml
+++ b/legacy-stack-authorization-server-start/legacy-stack-authorization-server-start--auth-server/src/main/resources/application.yml
@@ -1,6 +1,31 @@
 server:
   port: 8083
 spring:
+  security:
+    user:
+      name: john@test.com
+      password: $2a$10$yCl.WgsHZGpKeplZCVH1mea9IcCsbmLNXdbGJ511ws7AeyuLT6m9.
   devtools:
     livereload:
       port: 35731
+
+security:
+  oauth2:
+    authorization:
+      jwt:
+        key-alias: mytest
+        key-store: classpath:mytest.jks
+        key-store-password: mypass
+    client:
+      client-id: lssoClient
+      client-secret: lssoSecret
+      scope:
+        - read
+        - write
+      authorized-grant-types:
+        - authorization_code
+      registered-redirect-uri:
+        - http://localhost:8082/lsso-client/login/oauth2/code/custom
+      auto-approve-scopes:
+        - read
+        - write

--- a/legacy-stack-authorization-server-start/legacy-stack-authorization-server-start--client/src/main/resources/application.yml
+++ b/legacy-stack-authorization-server-start/legacy-stack-authorization-server-start--client/src/main/resources/application.yml
@@ -11,9 +11,10 @@ spring:
             redirect-uri: http://localhost:8082/lsso-client/login/oauth2/code/custom
         provider:
           custom:
-            authorization-uri: /
-            token-uri: /
-            user-info-uri: /
+            authorization-uri: http://localhost:8083/oauth/authorize
+            token-uri: http://localhost:8083/oauth/token
+            user-info-uri: http://localhost:8083/users/userinfo
+            user-name-attribute: preferred_username
   thymeleaf:
     cache: false
   devtools:

--- a/legacy-stack-authorization-server-start/legacy-stack-authorization-server-start--resource-server/src/main/resources/application.yml
+++ b/legacy-stack-authorization-server-start/legacy-stack-authorization-server-start--resource-server/src/main/resources/application.yml
@@ -9,7 +9,7 @@ spring:
     oauth2:
       resourceserver:
         jwt:
-          jwk-set-uri: http://
+          jwk-set-uri: http://localhost:8083/endpoint/jwks.json
   datasource:
     username: sa
     url: jdbc:h2:mem:testdb;DB_CLOSE_ON_EXIT=FALSE;

--- a/logout-with-oauth-and-oidc-start/logout-with-oauth-and-oidc-start--client/src/main/java/com/baeldung/lsso/spring/ClientSecurityConfig.java
+++ b/logout-with-oauth-and-oidc-start/logout-with-oauth-and-oidc-start--client/src/main/java/com/baeldung/lsso/spring/ClientSecurityConfig.java
@@ -1,16 +1,22 @@
 package com.baeldung.lsso.spring;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.oauth2.client.oidc.web.logout.OidcClientInitiatedLogoutSuccessHandler;
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
 import org.springframework.security.oauth2.client.web.OAuth2AuthorizedClientRepository;
 import org.springframework.security.oauth2.client.web.reactive.function.client.ServletOAuth2AuthorizedClientExchangeFilterFunction;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.logout.LogoutSuccessHandler;
 import org.springframework.web.reactive.function.client.WebClient;
 
 @Configuration
 public class ClientSecurityConfig {
+
+    @Autowired
+    private ClientRegistrationRepository clientRegistrationRepository;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {// @formatter:off
@@ -19,9 +25,15 @@ public class ClientSecurityConfig {
 	            .anyRequest().authenticated())
             .oauth2Login()
             .and()
-            .logout().logoutSuccessUrl("/");
+            .logout(logoutBuilder -> logoutBuilder.logoutSuccessHandler(oidcLogoutSuccessHandler()));
         return http.build();
     }// @formatter:on
+
+    private LogoutSuccessHandler oidcLogoutSuccessHandler() {
+        var handler = new OidcClientInitiatedLogoutSuccessHandler(clientRegistrationRepository);
+        handler.setPostLogoutRedirectUri("{baseUrl}");
+        return handler;
+    }
 
     @Bean
     WebClient webClient(ClientRegistrationRepository clientRegistrationRepository, OAuth2AuthorizedClientRepository authorizedClientRepository) {

--- a/logout-with-oauth-and-oidc-start/logout-with-oauth-and-oidc-start--client/src/main/resources/application.yml
+++ b/logout-with-oauth-and-oidc-start/logout-with-oauth-and-oidc-start--client/src/main/resources/application.yml
@@ -16,6 +16,7 @@ spring:
             user-info-uri: http://localhost:8083/auth/realms/baeldung/protocol/openid-connect/userinfo
             user-name-attribute: preferred_username
             jwk-set-uri: http://localhost:8083/auth/realms/baeldung/protocol/openid-connect/certs
+            issuer-uri: http://localhost:8083/auth/realms/baeldung
 
   thymeleaf:
     cache: false

--- a/oauth2-and-openid-connect-start/oauth2-and-openid-connect-start--client/src/main/resources/application.yml
+++ b/oauth2-and-openid-connect-start/oauth2-and-openid-connect-start--client/src/main/resources/application.yml
@@ -6,7 +6,7 @@ spring:
           custom:
             client-id: lssoClient
             client-secret: lssoSecret
-            scope: read,write
+            scope: read,write, openid
             authorization-grant-type: authorization_code
             redirect-uri: http://localhost:8082/lsso-client/login/oauth2/code/custom
         provider:
@@ -15,6 +15,7 @@ spring:
             token-uri: http://localhost:8083/auth/realms/baeldung/protocol/openid-connect/token
             user-info-uri: http://localhost:8083/auth/realms/baeldung/protocol/openid-connect/userinfo
             user-name-attribute: preferred_username
+            jwk-set-uri: http://localhost:8083/auth/realms/baeldung/protocol/openid-connect/certs
   thymeleaf:
     cache: false
   devtools:

--- a/token-revocation-start/token-revocation-start--resource-server/src/main/java/com/baeldung/lsso/spring/ResourceSecurityConfig.java
+++ b/token-revocation-start/token-revocation-start--resource-server/src/main/java/com/baeldung/lsso/spring/ResourceSecurityConfig.java
@@ -4,6 +4,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.oauth2.server.resource.OAuth2ResourceServerConfigurer;
 import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
@@ -18,8 +19,7 @@ public class ResourceSecurityConfig {
 	                .hasAuthority("SCOPE_write")
 	              .anyRequest()
 	                .authenticated())
-              .oauth2ResourceServer()
-                .jwt();
+              .oauth2ResourceServer(OAuth2ResourceServerConfigurer::opaqueToken);
         return http.build();
     }//@formatter:on
 

--- a/token-revocation-start/token-revocation-start--resource-server/src/main/resources/application.yml
+++ b/token-revocation-start/token-revocation-start--resource-server/src/main/resources/application.yml
@@ -8,9 +8,10 @@ spring:
   security:
     oauth2:
       resourceserver:
-        jwt:
-          issuer-uri: http://localhost:8083/auth/realms/baeldung
-          jwk-set-uri: http://localhost:8083/auth/realms/baeldung/protocol/openid-connect/certs
+        opaque-token:
+          introspection-uri: http://localhost:8083/auth/realms/baeldung/protocol/openid-connect/token/introspect
+          client-id: lssoClient
+          client-secret: lssoSecret
   datasource:
     username: sa
     url: jdbc:h2:mem:testdb;DB_CLOSE_ON_EXIT=FALSE;


### PR DESCRIPTION
Module 5 - Spring Security OAuth2 - OAuth2 Beyond the Basics - Deep-Dives

1. Configure spring boot oauth2 using SPA (Authorization Server should be configured for PKCE (Proof Key for Code Exchange) and S256 code challenge method and the CORS enabled). Added CORS configuration on the Resource Server. So the SPA should:
 - generate the state
 - generate code verifier for to generate code challenge value from it and to be sent to the token endpoint in order the Authorization Server to verify its value by hashing and comparing it with code challenge sent by the authorized endpoint.

 2. Created integration tests using RestAssured to test all the components work together as expected involved in the authorization flow.

 3. Configuring the Client to use the openid scope and therefore the opening-related classes for authorization (OidcAuthorizationCodeAuthenticationProvider, OidcIdToken, OidcUser, OAuth2AccessToken, and logout classes). This helps to get the ID token with access and refresh tokens and create an authorization object from it. Also, helps to use the OIDC logout features provided by the framework.

 4. Implemented logout from the OIDC provider using the OidcClientInitiatedLogoutSuccessHandler and implemented RP-initiated specification from the Openid Connect 1.0. Also, set the Valid Redirect URI in the Authorization server.

 5. Configuring the Client app and the Authorization Server to use client_credentials flow. Set up the application properties set up the OAuth2AuthorizedClientManager and configure the WebClient to use this manager. This will populate the access_token to the header and will automatically refresh it when the access token expires.

 6. Configure token revocation for the refresh token and configure the introspection endpoint for the opaque token that can be used with JWT on the Resource Server but this is not recommended, so better to revoke the refresh token and set the short-time lived access token.

 7. Configure the legacy authorization server itself using spring boot without any providers and connect the client and the Resource Server to communicate together.